### PR TITLE
Migrate CI to github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install dependencies
+      - name: Install Dependencies
         run: npm ci
       - name: Build
         run: npm run build --if-present
-      - name: Check linting
+      - name: Check Linting
         run: npm run lint
-      - name: Run test with coverage
+      - name: Run Test with Coverage
         run: npm run coverage
-      - name: Upload coverage
+      - name: Upload Coverage
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci
       - name: Build
         run: npm run build --if-present
-      - name: Check Linting
+      - name: Check linting
         run: npm run lint
       - name: Run test with coverage
         run: npm run coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run build --if-present
       - name: Check Linting
@@ -32,5 +32,4 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v1
         with:
-          verbose: true
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * 0" # weekly
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build --if-present
+      - name: Check Linting
+        run: npm run lint
+      - name: Run test with coverage
+        run: npm run coverage
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
+        with:
+          verbose: true
+          fail_ci_if_error: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - "node"
-  - "14"
-script:
-  - npm run lint
-  - npm run coverage
-after_success: npm run report

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # map-tree
 
-[![npm](https://img.shields.io/npm/v/map-tree.svg?logo=npm&style=flat-square)](https://www.npmjs.com/package/map-tree) [![Travis (.org)](https://img.shields.io/travis/repraze-org/map-tree.svg?logo=travis&style=flat-square)](https://travis-ci.org/repraze-org/map-tree) [![Codecov](https://img.shields.io/codecov/c/github/repraze-org/map-tree.svg?logo=codecov&style=flat-square)](https://codecov.io/gh/repraze-org/map-tree) [![GitHub](https://img.shields.io/github/license/repraze-org/map-tree.svg?logo=github&style=flat-square)](https://github.com/repraze-org/map-tree) [![npm](https://img.shields.io/npm/dm/map-tree.svg?logo=npm&style=flat-square)](https://www.npmjs.com/package/map-tree)
+[![npm](https://img.shields.io/npm/v/map-tree.svg?logo=npm&style=flat-square)](https://www.npmjs.com/package/map-tree)
+[![GitHub Workflow CI Status](https://img.shields.io/github/workflow/status/repraze-org/map-tree/CI?logo=github&style=flat-square)](https://github.com/repraze-org/map-tree/actions?query=workflow%3ACI)
+[![Codecov](https://img.shields.io/codecov/c/github/repraze-org/map-tree.svg?logo=codecov&style=flat-square)](https://codecov.io/gh/repraze-org/map-tree)
+[![GitHub](https://img.shields.io/github/license/repraze-org/map-tree.svg?logo=github&style=flat-square)](https://github.com/repraze-org/map-tree)
+[![npm](https://img.shields.io/npm/dm/map-tree.svg?logo=npm&style=flat-square)](https://www.npmjs.com/package/map-tree)
 
 MapTree structure, allows Maps to lookup elements in its Map children in a BFS way.
 
--   Solves Map inheritance
--   Allows overrides by setting keys on parents
--   Similar interface to the Map you love
--   Uses Map and Set under the hood to keep lookups and changes fast
--   Fundamental algorithm used is [Breadth-first search (BSF)](https://en.wikipedia.org/wiki/Breadth-first_search)
--   Does not test for cycles, thus does not support graphs
--   Dependency free
+- Solves Map inheritance
+- Allows overrides by setting keys on parents
+- Similar interface to the Map you love
+- Uses Map and Set under the hood to keep lookups and changes fast
+- Fundamental algorithm used is [Breadth-first search (BSF)](https://en.wikipedia.org/wiki/Breadth-first_search)
+- Does not test for cycles, thus does not support graphs
+- Dependency free
 
 ## Installation
 
@@ -21,11 +25,11 @@ MapTree structure, allows Maps to lookup elements in its Map children in a BFS w
 ```javascript
 const MapTree = require("map-tree");
 
-const foodMap = new MapTree([["steak", {value: 1}]]);
+const foodMap = new MapTree([["steak", { value: 1 }]]);
 
 const fruitMap = new MapTree();
-fruitMap.set("banana", {value: 2});
-fruitMap.set("apple", {value: 3});
+fruitMap.set("banana", { value: 2 });
+fruitMap.set("apple", { value: 3 });
 
 foodMap.children.add(fruitMap);
 foodMap.get("banana", true); // {value: 2}
@@ -33,7 +37,7 @@ foodMap.has("steak"); // true
 foodMap.has("apple"); // false (not traversing)
 
 for (let [key, value] of foodMap.entries(true)) {
-    // will traverse children too!
+  // will traverse children too!
 }
 ```
 
@@ -43,34 +47,34 @@ for (let [key, value] of foodMap.entries(true)) {
 new MapTree([iterable [, children]]);
 ```
 
--   **iterable** : Array or iterable object of key-value pairs.
+- **iterable** : Array or iterable object of key-value pairs.
 
--   **children** : Array or iterable object of MapTree objects defining the children of the new object.
+- **children** : Array or iterable object of MapTree objects defining the children of the new object.
 
 ## Properties
 
--   **Map.prototype.size** : Returns the number of key/value pairs in the MapTree object. It does not include children.
+- **Map.prototype.size** : Returns the number of key/value pairs in the MapTree object. It does not include children.
 
--   **Map.prototype.children** : Returns the MapTree children Set. The Set can be changed to add/remove/clear children. Property can be set provided an array or iterable object of MapTree objects to replace all children.
+- **Map.prototype.children** : Returns the MapTree children Set. The Set can be changed to add/remove/clear children. Property can be set provided an array or iterable object of MapTree objects to replace all children.
 
 ## Methods
 
--   **Map.prototype.clear()** : Removes all key/value pairs from the MapTree object. Does not clear the children.
+- **Map.prototype.clear()** : Removes all key/value pairs from the MapTree object. Does not clear the children.
 
--   **Map.prototype.delete(key)** : Removes element from MapTree and returns true if the element did not exist, or false if the element did not. It will not delete from the children.
+- **Map.prototype.delete(key)** : Removes element from MapTree and returns true if the element did not exist, or false if the element did not. It will not delete from the children.
 
--   **Map.prototype.entries(\[traverse\])** : Returns a new Iterator object that contains an array of [key, value] for each element in the MapTree object in insertion order. If traverse is true, the Iterator will include children [key, value] in a BFS order.
+- **Map.prototype.entries(\[traverse\])** : Returns a new Iterator object that contains an array of [key, value] for each element in the MapTree object in insertion order. If traverse is true, the Iterator will include children [key, value] in a BFS order.
 
--   **Map.prototype.forEach(callbackFn \[, traverse \[, thisArg\]\])** : Calls callbackFn once for each key-value pair present in the MapTree object, in insertion order. If traverse is true, key-value pair present in children will be provided in BFS order. If a thisArg parameter is provided to forEach, it will be used as the this value for each callback.
+- **Map.prototype.forEach(callbackFn \[, traverse \[, thisArg\]\])** : Calls callbackFn once for each key-value pair present in the MapTree object, in insertion order. If traverse is true, key-value pair present in children will be provided in BFS order. If a thisArg parameter is provided to forEach, it will be used as the this value for each callback.
 
--   **Map.prototype.get(key\[, traverse\])** : Returns the value associated to the key, or undefined if there is none. If traverse is true, the key will be matched with children in BFS order.
+- **Map.prototype.get(key\[, traverse\])** : Returns the value associated to the key, or undefined if there is none. If traverse is true, the key will be matched with children in BFS order.
 
--   **Map.prototype.has(key\[, traverse\])** : Returns a boolean asserting whether a value has been associated to the key in the MapTree object or not. If traverse is true, the key will be matched with children in BFS order.
+- **Map.prototype.has(key\[, traverse\])** : Returns a boolean asserting whether a value has been associated to the key in the MapTree object or not. If traverse is true, the key will be matched with children in BFS order.
 
--   **Map.prototype.keys(\[traverse\])** : Returns a new Iterator object that contains the keys for each element in the MapTree object in insertion order. If traverse is true, the Iterator will include children keys in a BFS order.
+- **Map.prototype.keys(\[traverse\])** : Returns a new Iterator object that contains the keys for each element in the MapTree object in insertion order. If traverse is true, the Iterator will include children keys in a BFS order.
 
--   **Map.prototype.set(key, value)** : Sets the value for the key in the MapTree object. Returns the MapTree object.
+- **Map.prototype.set(key, value)** : Sets the value for the key in the MapTree object. Returns the MapTree object.
 
--   **Map.prototype.values(\[traverse\])** : Returns a new Iterator object that contains the values for each element in the MapTree object in insertion order. If traverse is true, the Iterator will include children values in a BFS order.
+- **Map.prototype.values(\[traverse\])** : Returns a new Iterator object that contains the values for each element in the MapTree object in insertion order. If traverse is true, the Iterator will include children values in a BFS order.
 
--   **Map.prototype\[\@\@iterator\]()** : Returns a new Iterator object that contains an array of [key, value] for each element in the MapTree object in insertion order. It does not include children.
+- **Map.prototype\[\@\@iterator\]()** : Returns a new Iterator object that contains an array of [key, value] for each element in the MapTree object in insertion order. It does not include children.

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,12 +159,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@tootallnate/once": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
-      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "dev": true
-    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -188,15 +182,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "requires": {
-        "debug": "4"
-      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -281,12 +266,6 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
-      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -496,31 +475,6 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
-          }
-        }
-      }
-    },
-    "codecov": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.1.tgz",
-      "integrity": "sha512-Qm7ltx1pzLPsliZY81jyaQ80dcNR4/JpcX0IHCIWrHBXgseySqbdbYfkdiXd7o/xmzQpGRVCKGYeTrHUpn6Dcw==",
-      "dev": true,
-      "requires": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.3",
-        "js-yaml": "3.14.0",
-        "teeny-request": "6.0.1",
-        "urlgrey": "0.4.4"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
           }
         }
       }
@@ -1168,35 +1122,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "http-proxy-agent": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
-      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "dev": true,
-      "requires": {
-        "@tootallnate/once": "1",
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-      "dev": true,
-      "requires": {
-        "agent-base": "5",
-        "debug": "4"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-          "dev": true
-        }
-      }
-    },
     "husky": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/husky/-/husky-2.7.0.tgz",
@@ -1229,15 +1154,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
-    },
-    "ignore-walk": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
-      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-      "dev": true,
-      "requires": {
-        "minimatch": "^3.0.4"
-      }
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -1965,12 +1881,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-      "dev": true
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -2568,15 +2478,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "stream-events": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
-      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
-      "dev": true,
-      "requires": {
-        "stubs": "^3.0.0"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2612,12 +2513,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
-    },
-    "stubs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
-      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
       "dev": true
     },
     "supports-color": {
@@ -2667,19 +2562,6 @@
             "ansi-regex": "^4.1.0"
           }
         }
-      }
-    },
-    "teeny-request": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
-      "integrity": "sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^4.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.2.0",
-        "stream-events": "^1.0.5",
-        "uuid": "^3.3.2"
       }
     },
     "test-exclude": {
@@ -2765,12 +2647,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
-      "dev": true
     },
     "uuid": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
         "test": "mocha --color 'test/**/*.test.js'",
         "lint": "eslint **/*.js",
         "lint-fix": "eslint **/*.js --fix",
-        "coverage": "nyc --reporter=lcov npm run test",
-        "report": "codecov"
+        "coverage": "nyc --reporter=lcov npm run test"
     },
     "husky": {
         "hooks": {
@@ -19,7 +18,6 @@
     "license": "MIT",
     "devDependencies": {
         "chai": "^4.2.0",
-        "codecov": "^3.8.1",
         "eslint": "^6.8.0",
         "husky": "^2.7.0",
         "mocha": "^8.2.1",


### PR DESCRIPTION
### Purpose

Since travisci requires tokens to run CI, and you only get a limited 10k tokens per free account plans, open source repos with little activity need to migrate out.

### Approach

Here we migrate the whole CI pipeline to github actions with a new CI workflow.

### Test

Created a branch to test the new pipeline. Testing on all recent versions of nodejs and coverage is uploaded flawlessly to codecov.

### Checklist

N.A.

### Open Questions and Pre-Merge TODOs

N.A.
